### PR TITLE
Fix:APODVideo Rendering issue

### DIFF
--- a/app.js
+++ b/app.js
@@ -121,21 +121,30 @@ particlesJS("bg", {
       return response.json()
   }).then((data) => {
       console.log(data)
-      
-      displayData(data.url, data.explanation, data.title, data.date, data.copyright )
-     
+      displayData(data.url, data.explanation, data.title, data.date, data.copyright,data.media_type)
   })
   .catch((error) => console.error(error))
 
 
   //function to display data in apod section
-  function displayData(image, info, title, date, copyright){
-    document.getElementById("apod_img").src = image
-    document.getElementById("apod_info").textContent = info
-    document.getElementById("title").textContent = title
-    document.getElementById("date").textContent = date
-    document.getElementById("copyright").textContent = copyright
-
+  function displayData(media, info, title, date, copyright,mediatype){
+    if(mediatype === "video")  // Check media type
+    {
+      // Hide image container, display video container, and embed video
+      document.querySelector(".img").style.display = "none"; 
+      document.querySelector(".video").style.display = "block"; 
+      document.querySelector(".video").style.height = "80%"; 
+      document.getElementById("apod_video").innerHTML = `<iframe width="100%" height="100%" src="${media}" frameborder="0" allowfullscreen></iframe>`;
+  } else {
+      // Hide video container, display image container, and set image source
+      document.querySelector(".video").style.display = "none";
+      document.querySelector(".img").style.display = "block"; 
+      document.getElementById("apod_img").src = media; 
+  }
+  document.getElementById("apod_info").textContent = info;
+  document.getElementById("title").textContent = title;
+  document.getElementById("date").textContent = date;
+  document.getElementById("copyright").textContent = copyright;
   }
 
 

--- a/index.html
+++ b/index.html
@@ -89,6 +89,8 @@
       <div class="img">
            <img src="./assets/64e4e4aabd98a600197c0ca3.webp" id="apod_img" width="100%" height="100%">
       </div>
+      <div class="video" id="apod_video">
+   </div>
       <div class="info">
         <h5 id="copyright" align="center" > </h5>
         <h6 id="date" align="center"> </h6>

--- a/style.css
+++ b/style.css
@@ -61,7 +61,7 @@ body {
   height: 500px;
 }
 
-.img {
+.img,.video {
   width: 500px;
   height: 400px;
 }
@@ -69,13 +69,14 @@ body {
 .info {
   width: 500px;
   height: 100px;
+  margin-top: 1rem;
 }
 
 #apod_img {
   border-radius: 25px;
 }
 
-#apod_img:hover {
+#apod_img:hover,#apod_video:hover {
   color: white;
   box-shadow: 0 5px 15px #9000ff;
 }


### PR DESCRIPTION
## Bug Report: Video Rendering Issue in APOD Section of CosmoXplore Website

## Issue number 
<!-- Please make sure issue number is mention in Pull Request else PR will not be merged. 
eg : Issue No. : #4 -->

Issue No. : #21 


## Video/Screenshots (mandatory)
<!--Please try to attach the working video of your new deployed project here -->
<!-- It is not applicable for the templates of adding feature or fixing bugs -->
## Before:
![Screenshot 2024-05-10 232514](https://github.com/PranavBarthwal/cosmoXplore/assets/113124063/eaa637ff-5a0d-42fc-a2b6-5e4673805c78)

## After:
![Screenshot 2024-05-11 223803](https://github.com/PranavBarthwal/cosmoXplore/assets/113124063/633421ec-7afa-44ff-937c-53929db0f247)





## Checklist:

- [X] I have mentioned the issue number in my Pull Request.
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have gone through the  `contributing.md` file before contributing
<!-- [X] - put a cross/X inside [] to check the box -->

## Additional context:

In response to a usability issue, I've made adjustments to the JavaScript function `displayData()` to ensure proper rendering of both images and videos on the webpage. Here's a summary of the changes:

- Introduced conditional logic to distinguish between image and video media types.
- Adjusted CSS display properties to show/hide the appropriate containers (`img` and `video`).
- Dynamically set the source of the image or embed a video iframe based on the media type.

These changes enhance the user experience by seamlessly displaying media content and associated information on the webpage.