### PR TITLE
Enter datebox broken

### DIFF
--- a/style.css
+++ b/style.css
@@ -54,6 +54,8 @@ body {
 
 .input_container {
   display: flex;
+  flex-direction: row; 
+  flex-wrap: nowrap;
   width: 100%;
   justify-content: center;
   align-items: center;
@@ -67,6 +69,7 @@ body {
 
 .date_input {
   width: 700px;
+  border-radius: 5px;
   height:40px;
 }
 


### PR DESCRIPTION
# Enter datebox broken

## Issue number 
<!-- Please make sure issue number is mention in Pull Request else PR will not be merged. 
eg : Issue No. : #8 --> Enter datebox broken

Issue No. : 8


## Video/Screenshots (mandatory)
# Before
![329316470-c6751979-f33b-4d76-bdff-f889b0caf1d1](https://github.com/PranavBarthwal/cosmoXplore/assets/73558583/c6e58c29-09cf-4b66-8294-40af9a06c920)
# After
![image](https://github.com/PranavBarthwal/cosmoXplore/assets/73558583/6014c905-82b4-4786-a89b-d600a372b79d)


## Checklist:

- [x] I have mentioned the issue number in my Pull Request.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have gone through the  `contributing.md` file before contributing
<!-- [X] - put a cross/X inside [] to check the box -->

## Additional context:

Previously when you reduce screen size the input box and enter button both gets separated out but now both will remain attach.
Also, I found one more bug explain in issue no. #78 , if you assign me I will fix it immediately.
