### PR TITLE
Extending the date in viewing mars rover imagery

### DIFF
--- a/index.html
+++ b/index.html
@@ -195,7 +195,7 @@
 
 
 <div  class="input-group mb-4 input_container">
-  <input class="date_input" type="date" aria-label="Recipient's username" placeholder="Choose date from the date picker" aria-describedby="button-addon2" min="2019-01-01" max="2024-01-01" />
+  <input class="date_input" type="date" aria-label="Recipient's username" placeholder="Choose date from the date picker" aria-describedby="button-addon2" min="2012-08-06" max="2024-01-01" />
   <button class="btn btn-primary mars_button" type="button" id="button-addon2" onclick="displayRover()" >Enter</button>
 </div>
 


### PR DESCRIPTION
# Extending the date in viewing mar rover imagery #70

## Issue number 
Extending the date in viewing mar rover imagery #70

Fixes #
extended the beginnning date

## Video/Screenshots (mandatory)
![image](https://github.com/PranavBarthwal/cosmoXplore/assets/82147067/852d11fb-b125-48eb-b2d9-e08330567d4f)

## Checklist:

- [ X] I have mentioned the issue number in my Pull Request.
- [X ] I have commented my code, particularly in hard-to-understand areas
- [X ] I have gone through the  `contributing.md` file before contributing
<!-- [X] - put a cross/X inside [] to check the box -->

## Additional context:
