### PR TITLE
Resolved Overlapping of Chatbot and Scroll to Top Button

### DIFF
--- a/src/components/ScrollToTop/ScrollToTop.module.css
+++ b/src/components/ScrollToTop/ScrollToTop.module.css
@@ -1,11 +1,11 @@
 
 .btn{
     position: fixed;
-    right: 20px;
-    bottom: 100px;
+    left: 20px;
+    bottom: 21px;
     border-radius: 50%;
 }
-
+ 
 .scroll-btn{
     background-color: white;
     border:none;


### PR DESCRIPTION
Hi @PranavBarthwal, @surajvast1 & @harshit-sharmaaa,
closes #380 

considering the current positioning where the chatbot is in the rightmost bottom of the page and the scroll-to-top button is just above it, I adjusted the scroll-to-top button to be moved to the left side of the page to avoid overlap.

## Video/Screenshots (mandatory)
Here as you can see : 

![image](https://github.com/PranavBarthwal/cosmoXplore/assets/131389695/2cab942b-1cbb-4abf-b349-6dabe40835cd)

Please take a look.
## Checklist:

- [x] I have mentioned the issue number in my Pull Request.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have gone through the  `contributing.md` file before contributing
