### PR TITLE
Resolved Overlapping of Chatbot and Scroll to Top Button

### DIFF
--- a/src/components/Chatbot/chatbot.css
+++ b/src/components/Chatbot/chatbot.css
@@ -1,7 +1,7 @@
 /* Chatbot Icon */
 .chat-icon-container {
     position: fixed;
-    bottom: 20px;
+    bottom: 80px;
     right: 20px;
     z-index: 9999;
     transition: all 0.3s ease;

--- a/src/components/ScrollToTop/ScrollToTop.module.css
+++ b/src/components/ScrollToTop/ScrollToTop.module.css
@@ -2,7 +2,7 @@
 .btn{
     position: fixed;
     right: 20px;
-    bottom: 100px;
+    bottom: 20px;
     border-radius: 50%;
 }
 


### PR DESCRIPTION
Hi @surajvast1 ,
closes #397 

considering the current positioning where the chatbot is in the rightmost bottom of the page and the scroll-to-top button is just above it, I adjusted the scroll-to-top button and chatbot by interchanging their position to avoid overlap.

****Video/Screenshots (mandatory)****

Here as you can see :

![image](https://github.com/PranavBarthwal/cosmoXplore/assets/160386036/141242d0-7f70-4251-820c-f61a105aa13b)
