### PR TITLE
Cross icon should align side by side of refresh icon in open bot #403

### DIFF
--- a/src/components/Chatbot/chatbot.jsx
+++ b/src/components/Chatbot/chatbot.jsx
@@ -65,8 +65,8 @@ const Chatbot = () => {
         <div className="chat-popup-container">
           <div className="chat-popup-header">
             <h5>SpaceBot</h5>
-            <i className="fas fa-sync refresh-icon" onClick={handleRefresh}></i>
-            <i className="fas fa-times close-icon" onClick={toggleChatbot}></i>
+            <i style={{marginTop:'1.5%'}} className="fas fa-sync refresh-icon" onClick={handleRefresh}></i>
+            <i style={{marginTop:'5%'}} className="fas fa-times close-icon" onClick={toggleChatbot}></i>
           </div>
           <div className="chat-popup-body">
             <div className="chat-messages">


### PR DESCRIPTION
Cross icon should align side by side of refresh icon in open bot #403

## Issue number 


closes: #403 


## Video/Screenshots (mandatory)
![image](https://github.com/PranavBarthwal/cosmoXplore/assets/59639410/6a4dbb3c-ad7a-469a-9adc-8c68e8ca88fd)


## Checklist:

- [x] I have mentioned the issue number in my Pull Request.
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have gone through the  `contributing.md` file before contributing
<!-- [X] - put a cross/X inside [] to check the box -->

## Additional context:
